### PR TITLE
Temporarily not returning 404 when an asset cannot be found

### DIFF
--- a/explorer/src/service/asset.rs
+++ b/explorer/src/service/asset.rs
@@ -114,6 +114,7 @@ pub async fn get_asset(api: &Api, address: Path<String>) -> Result<AssetResponse
         }
     }
 
+    /*
     if assets.is_empty() {
         return Ok(AssetResponse::NotFound(Json(AssetResult {
             code: 404,
@@ -121,6 +122,7 @@ pub async fn get_asset(api: &Api, address: Path<String>) -> Result<AssetResponse
             data: None,
         })));
     }
+    */
 
     Ok(AssetResponse::Ok(Json(AssetResult {
         code: 200,


### PR DESCRIPTION
Let us keep the API for get_asset unchanged for now.